### PR TITLE
mkosi.finalize: explicitly specify python3

### DIFF
--- a/mkosi.finalize
+++ b/mkosi.finalize
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import ast
 import functools


### PR DESCRIPTION
Fedora has a strict policy about python version in shebang
https://fedoraproject.org/wiki/Changes/Make_ambiguous_python_shebangs_error