### PR TITLE
add kernel-install files

### DIFF
--- a/docs/fedora.md
+++ b/docs/fedora.md
@@ -132,8 +132,6 @@ The output image `mkosi.output/initrd_$KVER.cpio.zst` needs to be installed as
 `/boot/efi/$(cat /etc/machine-id)/$KVER/initrd` .
 `bootctl list` can be used verify the status.
 
-Currently there is no integration with `kernel-install` or other tools.
-
 ## Non-EFI
 
 ```

--- a/kernel-install/60-mkosi-initrd.install
+++ b/kernel-install/60-mkosi-initrd.install
@@ -1,0 +1,43 @@
+#!/usr/bin/bash
+export LANG=C
+
+COMMAND="$1"
+KERNEL_VERSION="$2"
+BOOT_DIR_ABS="$3"
+KERNEL_IMAGE="$4"
+
+INITRD="initrd"
+unset WITH_DRACUT
+
+if [ -x /usr/lib/kernel/install.d/50-dracut.install ] ; then
+    WITH_DRACUT="yes"
+    INITRD="initrd-mkosi"
+fi
+
+# if we have GRUB2 variation of BLS
+# we need to redefine some names
+if [ ! -d "$BOOT_DIR_ABS" ] ; then
+    BOOT_DIR_ABS="/boot"
+    if [ ! "$WITH_DRACUT" ] ; then
+        INITRD="initramfs-${KERNEL_VERSION}.img"
+    else
+        INITRD="initramfs-${KERNEL_VERSION}-mkosi.img"
+    fi
+fi
+
+case "$COMMAND" in
+    add)
+        BUILD_DIR=$(mktemp -d -p /var/tmp)
+        pushd "$BUILD_DIR" || exit 1
+        cp /usr/lib/mkosi-initrd/fedora.mkosi /usr/lib/mkosi-initrd/mkosi.finalize ./
+        mkosi --default fedora.mkosi --finalize-script=mkosi.finalize  -f --image-version="$KERNEL_VERSION" --environment=KERNEL_VERSION="$KERNEL_VERSION"
+        mv "mkosi.output/initrd_${KERNEL_VERSION}.cpio.zstd"  "$BOOT_DIR_ABS/$INITRD"
+        rm -rf "$BUILD_DIR"
+        popd || :
+        ;;
+
+    remove)
+        rm -f -- "$BOOT_DIR_ABS/$INITRD"
+        ;;
+esac
+exit 0

--- a/kernel-install/95-mkosi-initrd-loaderentry.install
+++ b/kernel-install/95-mkosi-initrd-loaderentry.install
@@ -1,0 +1,54 @@
+#!/usr/bin/bash
+export LANG=C
+
+COMMAND="$1"
+KERNEL_VERSION="$2"
+BOOT_DIR_ABS="$3"
+KERNEL_IMAGE="$4"
+
+#we run only if we use dracut as well
+[ -x /usr/lib/kernel/install.d/50-dracut.install ] || exit 0
+
+if [[ ${KERNEL_INSTALL_MACHINE_ID+x} ]]; then
+    MACHINE_ID=$KERNEL_INSTALL_MACHINE_ID
+elif [[ -f /etc/machine-id ]] ; then
+    read -r MACHINE_ID < /etc/machine-id
+fi
+
+if ! [[ $MACHINE_ID ]] ; then
+    exit 0
+fi
+
+INITRD="initrd-mkosi"
+BOOT_ROOT=${BOOT_DIR_ABS%/$MACHINE_ID/$KERNEL_VERSION}
+LOADER_ENTRY="$BOOT_ROOT/loader/entries/$MACHINE_ID-$KERNEL_VERSION-mkosi.conf"
+LOADER_ENTRY_ORIG="$BOOT_ROOT/loader/entries/$MACHINE_ID-$KERNEL_VERSION.conf"
+unset GRUB2_BLS
+
+# if we have GRUB2 variation of BLS
+# we need to redefine some names
+if [ ! -d "$BOOT_DIR_ABS" ] ; then
+    GRUB2_BLS="yes"
+    BOOT_DIR_ABS="/boot"
+    INITRD="initramfs-${KERNEL_VERSION}-mkosi.img"
+    LOADER_ENTRY="/boot/loader/entries/$MACHINE_ID-$KERNEL_VERSION-mkosi.conf"
+    LOADER_ENTRY_ORIG="/boot/loader/entries/$MACHINE_ID-$KERNEL_VERSION.conf"
+fi
+
+case "$COMMAND" in
+    add)
+        cp -aT "$LOADER_ENTRY_ORIG" "$LOADER_ENTRY"
+        sed -i "s#\(^title.*\)#\1 - mkosi#" "$LOADER_ENTRY"
+        if [ ! "$GRUB2_BLS" ] ; then
+            sed -i "s#^initrd.*#initrd\t/$MACHINE_ID/$KERNEL_VERSION/$INITRD#" "$LOADER_ENTRY"
+        else
+            sed -i "s#^initrd.*#initrd\t/$INITRD#" "$LOADER_ENTRY"
+            grub2-editenv - set "saved_entry=${BLS_ID}"
+        fi
+        ;;
+
+    remove)
+        rm -f -- "$LOADER_ENTRY"
+        ;;
+esac
+exit 0


### PR DESCRIPTION
60-mkosi-initrd.install builds the initrd using mkosi
and puts it into a proper place.

Since we might want to run in parallel with dracut, the script checks
if dracut is present and in such case it creates an initrd
with a different suffix.

But in such case, we also need to also create a new BLS entry and that's
why we also have 95-mkosi-initrd-loaderentry.install. This ones copies
the entry from dracut based initrd and edits the initrd line.