### PR TITLE
fix exception handling

### DIFF
--- a/mkosi.finalize
+++ b/mkosi.finalize
@@ -54,7 +54,7 @@ def copy_in_modules_from_rpmls(root, kver):
     rpm = f'kernel-core-{kver}'
     try:
         out = subprocess.check_output(['rpm', '-ql', rpm], text=True)
-    except (FileNotFoundError, CalledProcessError) as e:
+    except (FileNotFoundError, subprocess.CalledProcessError) as e:
         print(f'Cannot query file list of {rpm}:', e)
         return False
 


### PR DESCRIPTION
Hi,

fix exception handling to prevent:

```
Installing modules for kernel 6.0.0-server-0.rc5.3omv4090
Traceback (most recent call last):
  File "/usr/lib/mkosi-initrd/mkosi.finalize", line 56, in copy_in_modules_from_rpmls
    out = subprocess.check_output(['rpm', '-ql', rpm], text=True)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.11/subprocess.py", line 465, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.11/subprocess.py", line 569, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['rpm', '-ql', 'kernel-core-6.0.0-server-0.rc5.3omv4090']' returned non-zero exit status 1.
```