### PR TITLE
Stop using pushd

### DIFF
--- a/kernel-install/50-mkosi-initrd.install
+++ b/kernel-install/50-mkosi-initrd.install
@@ -20,9 +20,9 @@ case "$COMMAND" in
         [ "$#" -gt "$INITRD_OPTIONS_SHIFT" ] && exit 0
 
         BUILD_DIR=$(mktemp -d -p /var/tmp)
-        pushd "$BUILD_DIR"
         (
             [ "$KERNEL_INSTALL_VERBOSE" -gt 0 ] && set -x
+            cd "$BUILD_DIR"
 
             mkosi --default /usr/lib/mkosi-initrd/fedora.mkosi \
                   --finalize-script=/usr/lib/mkosi-initrd/mkosi.finalize \
@@ -31,7 +31,6 @@ case "$COMMAND" in
                   -o "${KERNEL_INSTALL_STAGING_AREA}/initrd"
             rm -rf "$BUILD_DIR"
         )
-        popd
         ;;
 
     remove)


### PR DESCRIPTION
The lone directory name without any context at the end of output was confusing and ugly. Let's just log the cd if verbosity was requested. (pushd would prints the whole "stack", which is very ugly too.)