### PR TITLE
Add PyLint GitHub Action & Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+---
+
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 2

--- a/.github/workflows/differential-pylint.yml
+++ b/.github/workflows/differential-pylint.yml
@@ -1,0 +1,38 @@
+---
+
+name: Differential PyLint
+
+on:
+  pull_request:
+    branches: [ main ]
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+
+    steps:
+      - name: Repository checkout
+        uses: actions/checkout@v3
+
+      - id: PyLint
+        name: Differential PyLint
+        uses: fedora-copr/vcs-diff-lint-action@v1
+
+      - if: ${{ always() }}
+        name: Upload artifact with detected PyLint defects in SARIF format
+        uses: actions/upload-artifact@v3
+        with:
+          name: Differential PyLint SARIF
+          path: ${{ steps.PyLint.outputs.sarif }}
+
+      - if: ${{ always() }}
+        name: Upload SARIF to GitHub using github/codeql-action/upload-sarif
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: ${{ steps.PyLint.outputs.sarif }}


### PR DESCRIPTION
The GitHub Action `fedora-copr/vcs-diff-lint-action` allows to lint python scripts using PyLint and Mypy. It performs differential scans and reports only newly added defects.

Documentation of `vcs-diff-lint` - https://github.com/fedora-copr/vcs-diff-lint#readme

---

Also, adding Dependabot to update outdated GitHub Actions.